### PR TITLE
docs(go): update Go code standards with additional guidelines

### DIFF
--- a/claude-code/code-standards/go/CLAUDE.md
+++ b/claude-code/code-standards/go/CLAUDE.md
@@ -9,6 +9,7 @@ Unless otherwise specified, you MUST use the following packages:
     - Each package must have a `logrus.FieldLogger` instance passed in via the constructor. The package should add its own fields to its log instance. E.g. `log.WithField("package", "user")`
     - Use `log.WithField("field", "value")` to add fields to the log instance.
     - Use `log.WithFields(logrus.Fields{"key": "value", "key2": "value2"})` to add multiple fields to the log instance.
+    - NEVER log any sensitive information
 - CLI: `github.com/spf13/cobra`
 
 ## Domain-Driven Structure
@@ -37,7 +38,7 @@ order/
 
 Create sub-packages when components:
 - Have different reasons to change
-- Could be used independently  
+- Could be used independently
 - Need separate testing boundaries
 
 Otherwise, use files within a single package.
@@ -61,7 +62,7 @@ node/
 ├── p2p/         # Could be its own library
 └── api/         # Could serve different p2p impls
 
-// Together: Tightly coupled logic  
+// Together: Tightly coupled logic
 p2p/
 ├── p2p.go       # Main logic
 ├── reqresp.go   # Just another file
@@ -102,13 +103,39 @@ Every domain package MUST:
    - `Start(ctx context.Context) error` - Heavy initialization here
    - `Stop() error` - Cleanup
 
+Additionally:
+
+- You almost never need a pointer to an interface. You should be passing interfaces as values—the underlying data can still be a pointer.
+- Always verify interface compliance at compile time where appropriate, eg: `var _ http.Handler = (*Handler)(nil)`
+
+## Initialising
+
+You must:
+- Prefer `make(..)` for empty maps and maps populated dynamically.
+- Always provide capacity hints when initializing maps with `make()`
+- Always provide capacity hints when initializing slices with `make()`, particularly when appending.
+
+## Context Propagation
+
+- All methods that do I/O or can block MUST accept `context.Context` as first parameter
+- Context should flow through the entire call stack
+- Avoid storing context in structs
+
+## Testing Standards
+
+- Utilise table-driven tests for multiple scenarios.
+- Use `testify/assert` or `testify/require` for assertions.
+- Mock interfaces, not implementations.
+- Aim for 70% test coverage of critical code-paths.
+- You MUST always include the `-race` flag when executing `go test`.
+
 ## Naming Rules
 
 - NO package stuttering: `user.User` not `user.UserUser`
 - NO generic packages: `types/`, `utils/`, `common/`, `models/`, `helpers/`
 - NO generic files: `helpers.go`, `utils.go`, `types.go`
 
-## Example
+### Example
 
 ```go
 // user/user.go
@@ -131,3 +158,20 @@ func NewService(cfg Config) Service {
 ```
 
 **Key: Package by cohesion - types, functions, and helpers that change together belong together.**
+
+### Error Handling
+- No errors are to be left unchecked.
+- Wrap errors with context using `fmt.Errorf` with `%w` verb
+- Create custom error types when needed for error handling logic
+- Log errors at appropriate levels (debug, info, warn, error)
+
+## Style
+
+- Avoid overly long lines; aim for a soft line length limit of 99 characters.
+- Always group similar dependencies/imports, ensuring they are ordered by standard library, followed by everything else.
+- Follow standard Go conventions
+
+## Linting
+
+- If the project contains a `.golangci.yml` file, please respect it as best you can.
+- `golangci-lint` is our preferred linter and if executed, should always be done so with the `--new-from-rev="origin/master"` flag to ensure only your changes are linted.


### PR DESCRIPTION
Adds new sections for:
- Context Propagation
- Testing Standards
- Error Handling
- Style
- Linting

Also includes minor updates to existing sections, such as:
- Adding a rule to never log sensitive information.
- Clarifying interface pointer usage.
- Providing guidance on map and slice initialization.