### PR TITLE
feat: Implement local code standards management

### DIFF
--- a/claude-code/code-standards/config.json
+++ b/claude-code/code-standards/config.json
@@ -3,13 +3,13 @@
     "go": {
       "name": "Go",
       "patterns": ["*.go", "go.mod", "go.sum"],
-      "standards_url": "https://raw.githubusercontent.com/ethpandaops/ai-cookbook/master/claude-code/code-standards/go/CLAUDE.md",
+      "standards_path": "claude-code/code-standards/go/CLAUDE.md",
       "enabled": true
     },
     "python": {
       "name": "Python",
       "patterns": ["*.py"],
-      "standards_url": "https://raw.githubusercontent.com/ethpandaops/ai-cookbook/master/claude-code/code-standards/python/CLAUDE.md",
+      "standards_path": "claude-code/code-standards/python/CLAUDE.md",
       "enabled": true
     }
   }


### PR DESCRIPTION
Code standards are now copied to `~/.claude/ethpandaops/code-standards/` instead of being fetched from remote URLs