### PR TITLE
feat: add golangci-lint hook for automated Go linting

### DIFF
--- a/claude-code/hooks/golangci-lint/config.json
+++ b/claude-code/hooks/golangci-lint/config.json
@@ -1,0 +1,10 @@
+{
+  "name": "golangci-lint",
+  "description": "Runs golangci-lint on Go files to catch linting issues",
+  "hook_type": "PostToolUse",
+  "matcher": "Write|Edit|MultiEdit|str_replace_editor|str_replace_based_edit_tool",
+  "requirements": {
+    "commands": ["golangci-lint", "jq"],
+    "description": "Requires golangci-lint and jq to be installed"
+  }
+}

--- a/claude-code/hooks/golangci-lint/deps.sh
+++ b/claude-code/hooks/golangci-lint/deps.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check for jq
+if command_exists jq; then
+    echo -e "${GREEN}✓ jq is installed${NC}"
+else
+    echo -e "${RED}✗ jq is not installed${NC}"
+    echo -e "${YELLOW}Install jq:${NC}"
+    echo "  macOS: brew install jq"
+    echo "  Ubuntu/Debian: sudo apt-get install jq"
+    echo "  CentOS/RHEL: sudo yum install jq"
+    echo "  Windows: choco install jq"
+    exit 1
+fi
+
+# Check for golangci-lint
+if command_exists golangci-lint; then
+    version=$(golangci-lint --version 2>/dev/null | head -n1)
+    echo -e "${GREEN}✓ golangci-lint is installed${NC} ($version)"
+    
+    # Check if version supports the required flags (v1.21.0+ has --output.tab.path)
+    version_num=$(echo "$version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+    if [[ -n "$version_num" ]]; then
+        # Convert version to comparable number (e.g., 1.21.0 -> 10210)
+        IFS='.' read -ra VER <<< "$version_num"
+        version_compare=$((VER[0] * 10000 + VER[1] * 100 + VER[2]))
+        min_version=$((1 * 10000 + 21 * 100 + 0)) # 1.21.0
+        
+        if [[ $version_compare -lt $min_version ]]; then
+            echo -e "${RED}✗ golangci-lint $version_num is too old${NC}"
+            echo -e "${YELLOW}Required: v1.21.0 or later for --output.tab.path support${NC}"
+            echo -e "${YELLOW}Current: $version_num${NC}"
+            echo ""
+            echo -e "${YELLOW}Update golangci-lint:${NC}"
+            echo "  macOS: brew upgrade golangci-lint"
+            echo "  Linux: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$(go env GOPATH)/bin"
+            echo "  Or visit: https://golangci-lint.run/usage/install/"
+            exit 1
+        fi
+    fi
+else
+    echo -e "${RED}✗ golangci-lint is not installed${NC}"
+    echo -e "${YELLOW}Install golangci-lint:${NC}"
+    echo "  macOS: brew install golangci-lint"
+    echo "  Linux: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$(go env GOPATH)/bin"
+    echo "  Windows: choco install golangci-lint"
+    echo "  Or visit: https://golangci-lint.run/usage/install/"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ All dependencies are satisfied${NC}"

--- a/claude-code/hooks/golangci-lint/hook.sh
+++ b/claude-code/hooks/golangci-lint/hook.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -e
+
+
+# Find golangci-lint config file in current directory or parent directories
+find_golangci_config() {
+    local current_dir="$(pwd)"
+    
+    # Check current directory and walk up to root
+    while [[ "$current_dir" != "/" ]]; do
+        # Check for .golangci.yml
+        if [[ -f "$current_dir/.golangci.yml" ]]; then
+            echo "$current_dir/.golangci.yml"
+            return 0
+        fi
+        
+        # Check for .golangci.yaml
+        if [[ -f "$current_dir/.golangci.yaml" ]]; then
+            echo "$current_dir/.golangci.yaml"
+            return 0
+        fi
+        
+        # Move up one directory
+        current_dir="$(dirname "$current_dir")"
+    done
+    
+    # No config file found
+    return 1
+}
+
+# Check if we're in a git repository
+is_git_repo() {
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# Get the appropriate revision for --new-from-rev
+get_base_revision() {
+    if is_git_repo; then
+        # Try to get HEAD~1, fallback to initial commit
+        if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            echo "HEAD~1"
+        else
+            # Repository has only one commit, use empty tree
+            echo "$(git hash-object -t tree /dev/null)"
+        fi
+    else
+        # Not in a git repo, return empty (will skip --new-from-rev)
+        echo ""
+    fi
+}
+
+# Read JSON input from stdin
+input=$(cat)
+
+# Extract file path based on tool type (matching gofmt logic)
+tool_name=$(echo "$input" | jq -r '.tool_name')
+case "$tool_name" in
+    "Write"|"Edit"|"MultiEdit")
+        file_path=$(echo "$input" | jq -r '.tool_input.file_path')
+        ;;
+    "str_replace_editor"|"str_replace_based_edit_tool")
+        file_path=$(echo "$input" | jq -r '.tool_input.command_id // .tool_input.file_path')
+        ;;
+    *)
+        echo "Unknown tool: $tool_name"
+        exit 1
+        ;;
+esac
+
+# Only process Go files
+if [[ ! "$file_path" =~ \.go$ ]]; then
+    exit 0
+fi
+
+# Verify file exists
+if [[ ! -f "$file_path" ]]; then
+    echo "File not found: $file_path"
+    exit 1
+fi
+
+# Get package directory
+package_dir=$(dirname "$file_path")
+
+# Change to package directory for analysis
+cd "$package_dir"
+
+# Check for golangci-lint configuration file
+if ! config_file=$(find_golangci_config); then
+    # Silent exit when no config file found
+    exit 0
+fi
+
+# Build golangci-lint command with compact output
+cmd="golangci-lint run"
+
+# Add --new-from-rev if in git repo
+base_rev=$(get_base_revision)
+if [[ -n "$base_rev" ]]; then
+    cmd="$cmd --new-from-rev=$base_rev"
+fi
+
+# Add compact output flags to minimize token usage
+cmd="$cmd --output.tab.path=stdout"
+cmd="$cmd --output.tab.print-linter-name=false"
+cmd="$cmd --output.tab.colors=false"
+cmd="$cmd --show-stats=false"
+cmd="$cmd --max-issues-per-linter=20"
+cmd="$cmd --max-same-issues=3"
+
+# Add package path (current directory)
+cmd="$cmd ./..."
+
+# Run golangci-lint and capture output
+set +e  # Don't exit on command failure
+output=$($cmd 2>&1)
+exit_code=$?
+set -e  # Re-enable exit on error
+
+if [[ $exit_code -eq 0 ]]; then
+    # Success: no issues found, exit silently
+    exit 0
+elif [[ $exit_code -eq 1 ]]; then
+    # Issues found: send output to Claude
+    echo "$output" >&2
+    exit 2
+elif [[ $exit_code -eq 3 ]]; then
+    # Failure (syntax errors, etc.): send to Claude to fix
+    echo "# golangci-lint failed due to syntax errors or compilation issues:" >&2
+    echo "$output" >&2
+    exit 2
+else
+    # Other error (exit code 2, 4, 5, etc.): non-blocking error
+    echo "# golangci-lint failed with exit code $exit_code" >&2
+    if [[ -n "$output" ]]; then
+        echo "$output" >&2
+    else
+        echo "# No output from golangci-lint" >&2
+    fi
+    exit 1
+fi


### PR DESCRIPTION
## Summary
Add a new Claude Code hook that automatically runs golangci-lint after Go file edits, providing automated linting alongside the existing gofmt hook.

## Features
- **Opt-in behavior**: Only runs when `.golangci.yml`/`.golangci.yaml` config files are present
- **Fast execution**: Uses `--new-from-rev HEAD~1` to analyze only recent changes  
- **Compact output**: Tab format with minimal verbosity to reduce token usage
- **Git-aware**: Works with or without git repository
- **Package-level analysis**: Proper Go type checking and import analysis
- **Smart exit codes**: Sends linting issues to Claude for automatic fixing

## How it works
1. Runs after gofmt in sequential order (both hooks use PostToolUse)
2. Searches for golangci-lint config files from file directory up to root
3. If no config found, exits silently (opt-in behavior)
4. If config found, runs `golangci-lint run --new-from-rev HEAD~1 --output.tab.path=stdout ./...`
5. Exit code 2 sends any linting issues to Claude for automatic resolution

## Installation
```bash
python scripts/install-hooks.py --install golangci-lint
```

## Test plan
- [x] Hook correctly detects Go files vs non-Go files
- [x] Hook exits silently when no .golangci.yml config present
- [x] Hook runs golangci-lint when config is present
- [x] Hook uses compact tab output format
- [x] Hook sends linting issues to Claude via exit code 2
- [x] Hook works alongside existing gofmt hook
- [x] Dependencies script validates golangci-lint version compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)