### PR TITLE
Update besu repo reference to besu-eth/besu

### DIFF
--- a/claude-code/commands/parallel-repository-tasks.md
+++ b/claude-code/commands/parallel-repository-tasks.md
@@ -47,7 +47,7 @@ Examples (Execution Layer repositories):
 - https://github.com/NethermindEth/nethermind
 - https://github.com/paradigmxyz/reth
 - https://github.com/erigontech/erigon
-- https://github.com/hyperledger/besu
+- https://github.com/besu-eth/besu
 
 Enter repositories (one per line, empty line to finish):
 ```

--- a/claude-code/skills/eip/deep-dive.md
+++ b/claude-code/skills/eip/deep-dive.md
@@ -37,7 +37,7 @@ This file contains the detailed instructions for performing follow-up analysis a
 | Nethermind | `https://github.com/NethermindEth/nethermind.git` |
 | Reth | `https://github.com/paradigmxyz/reth.git` |
 | Erigon | `https://github.com/erigontech/erigon.git` |
-| Besu | `https://github.com/hyperledger/besu.git` |
+| Besu | `https://github.com/besu-eth/besu.git` |
 
 ## Execution Strategy
 


### PR DESCRIPTION
## Summary
- Update all references from `hyperledger/besu` to `besu-eth/besu` to reflect the repository migration

## Test plan
- [ ] Verify CI workflows still resolve the correct besu images/repos