### PR TITLE
docs(tailwindcss): update standards to v4.3

### DIFF
--- a/claude-code/code-standards/tailwindcss/CLAUDE.md
+++ b/claude-code/code-standards/tailwindcss/CLAUDE.md
@@ -2,27 +2,32 @@
 
 ## Core Principles
 
-- **Always use Tailwind CSS v4.1+** - Ensure the codebase is using the latest version
+- **Always use Tailwind CSS v4.3+** - Ensure the codebase is using the latest stable version (v4.3.x as of mid-2026)
 - **Do not use deprecated or removed utilities** - ALWAYS use the replacement
-- **Never use `@apply`** - Use CSS variables, the `--spacing()` function, or framework components instead
+- **Never use `@apply`** - Use `@utility`, CSS variables, the `--spacing()` function, or framework components instead
+- **Never construct class names dynamically** - Tailwind detects classes by scanning source files for complete, unbroken strings
 - **Check for redundant classes** - Remove any classes that aren't necessary
 - **Group elements logically** to simplify responsive tweaks later
 
-## Upgrading to Tailwind CSS v4
+## Class Detection and Source Files
 
-### Before Upgrading
+Tailwind v4 scans source files as plain text and only generates CSS for class names it finds as **complete strings**:
 
-- **Always read the upgrade documentation first** - Read https://tailwindcss.com/docs/upgrade-guide and https://tailwindcss.com/blog/tailwindcss-v4 before starting an upgrade.
-- Ensure the git repository is in a clean state before starting
+```jsx
+// ❌ Never build class names dynamically - these classes won't be generated
+<div class={`text-${error ? 'red' : 'green'}-600`}></div>
 
-### Upgrade Process
+// ✅ Always map to complete class names
+<div class={error ? 'text-red-600' : 'text-green-600'}></div>
+```
 
-1. Run the upgrade command: `npx @tailwindcss/upgrade@latest` for both major and minor updates
-2. The tool will convert JavaScript config files to the new CSS format
-3. Review all changes extensively to clean up any false positives
-4. Test thoroughly across your application
+- Use `@source "../node_modules/@my-company/ui-lib"` to scan paths not covered by automatic source detection (e.g. libraries, monorepo packages)
+- Use `@source not "../src/legacy"` to exclude paths from scanning
+- Use `@source inline("underline")` to safelist classes that never appear in source files (supports brace expansion: `@source inline("{hover:,}bg-red-{50,{100..900..100},950}")`)
 
-## Breaking Changes Reference
+## Legacy Utilities Reference
+
+LLMs are trained on large amounts of v3 code - never emit these legacy class names.
 
 ### Removed Utilities (NEVER use these in v4)
 
@@ -39,6 +44,7 @@
 | `overflow-ellipsis`     | `text-ellipsis`                                   |
 | `decoration-slice`      | `box-decoration-slice`                            |
 | `decoration-clone`      | `box-decoration-clone`                            |
+| `start-*` / `end-*`     | `inset-s-*` / `inset-e-*` (deprecated in v4.2)    |
 
 ### Renamed Utilities (ALWAYS use the v4 name)
 
@@ -57,6 +63,20 @@
 | `rounded`          | `rounded-sm`       |
 | `outline-none`     | `outline-hidden`   |
 | `ring`             | `ring-3`           |
+
+Notes on the renames:
+
+- The bare utilities (`shadow`, `blur`, `rounded`, `ring`) are still valid v4 classes, but they map to different values than in v3 - only use them when you actually mean the v4 value
+- `outline-none` in v4 sets a real `outline-style: none`; use `outline-hidden` for an invisible outline that still shows in forced-colors mode (the accessible default for focus styles)
+- Bare `ring` in v4 is a 1px ring in `currentColor`; use `ring-3` when you want the old v3 appearance (3px)
+
+## v4 Syntax Rules
+
+- **Important modifier goes at the end**: `bg-red-500!` (not `!bg-red-500`)
+- **CSS variable shorthand uses parentheses**: `bg-(--brand-color)` instead of the ambiguous v3 form `bg-[--brand-color]`
+- **Prefixes are variant-style**: `@import "tailwindcss" prefix(tw);` then `tw:flex tw:hover:bg-red-500`
+- **Stacked variants apply left-to-right** (v3 was right-to-left): `*:first:pt-0`, not `first:*:pt-0`
+- **`theme()` is deprecated** - use CSS theme variables like `var(--color-red-500)` instead
 
 ## Layout and Spacing Rules
 
@@ -104,6 +124,7 @@ Gap provides consistent spacing without edge cases (no extra space on last items
 ### General Spacing Guidelines
 
 - **Prefer top and left margins** over bottom and right margins (unless conditionally rendered)
+- **Use logical properties when direction matters** - `ms-*`/`me-*` for inline start/end, and `mbs-*`/`mbe-*`/`pbs-*`/`pbe-*` (v4.2) for block start/end; these adapt automatically to RTL and vertical writing modes
 - **Use padding on parent containers** instead of bottom margins on the last child
 - **Always use `min-h-dvh` instead of `min-h-screen`** - `min-h-screen` is buggy on mobile Safari
 - **Prefer `size-*` utilities** over separate `w-*` and `h-*` when setting equal dimensions
@@ -128,7 +149,7 @@ Gap provides consistent spacing without edge cases (no extra space on last items
 
 ### Font Size Reference
 
-Be precise with font sizes - know the actual pixel values:
+Be precise with font sizes - know the default theme values (projects can override these via `--text-*` theme variables):
 
 - `text-xs` = 12px
 - `text-sm` = 14px
@@ -175,7 +196,7 @@ Be precise with font sizes - know the actual pixel values:
 
 - Use the plain `dark:` variant pattern
 - Put light mode styles first, then dark mode styles
-- Ensure `dark:` variant comes before other variants
+- When stacking variants, write `dark:` first as a convention (e.g. `dark:hover:bg-gray-800`) - note that stacked variants apply left-to-right in v4
 
 ```html
 <!-- ✅ Correct dark mode pattern -->
@@ -228,6 +249,16 @@ Use the dedicated `--spacing()` function for spacing calculations:
 }
 ```
 
+### The `--alpha()` Function
+
+Use `--alpha()` to adjust the opacity of a color in custom CSS:
+
+```css
+.custom-element {
+  color: --alpha(var(--color-lime-300) / 50%);
+}
+```
+
 ### Extending theme values
 
 Use CSS to extend theme values:
@@ -245,6 +276,37 @@ Use CSS to extend theme values:
   <!-- ... -->
 </div>
 ```
+
+### Custom Utilities and Variants
+
+Use `@utility` (not `@apply` or plain CSS classes) to define custom utilities - they work with all variants and are sorted into the correct cascade layer:
+
+```css
+/* Simple utility */
+@utility content-auto {
+  content-visibility: auto;
+}
+
+/* Functional utility with a value, using --default() for a fallback (v4.3) */
+@utility tab-* {
+  tab-size: --value(integer, --default(4));
+}
+```
+
+Use `@custom-variant` to define new variants, and `@variant` to use variants inside custom CSS (v4.3 supports stacked `@variant hover:focus` and compound `@variant hover, focus`):
+
+```css
+@custom-variant theme-midnight (&:where([data-theme="midnight"] *));
+
+.button {
+  background: var(--color-sky-500);
+  @variant hover, focus {
+    background: var(--color-sky-600);
+  }
+}
+```
+
+Use `@reference "../app.css";` at the top of CSS modules or Vue/Svelte `<style>` blocks to access theme variables and variants without duplicating the emitted CSS.
 
 ## New v4 Features
 
@@ -298,6 +360,91 @@ Use the new composable mask utilities for image and gradient masks:
 <!-- ✅ Radial gradient masks -->
 <div class="mask-radial-[100%_100%] mask-radial-from-75% mask-radial-at-left">
   Radial mask
+</div>
+```
+
+### Text Wrapping (v4.1)
+
+Use `wrap-break-word` and `wrap-anywhere` to control how long words break:
+
+```html
+<p class="wrap-break-word">Breaks long words at arbitrary points if needed</p>
+<div class="flex">
+  <p class="wrap-anywhere">Use in flex layouts where break-word alone won't shrink</p>
+</div>
+```
+
+### Useful v4.0/v4.1 Variants
+
+- `not-*` - negate variants or media queries: `not-hover:opacity-75`, `not-supports-hanging-punctuation:px-4`
+- `starting:` - `@starting-style` entry transitions without JavaScript
+- `in-*` - like `group-*` but without needing a `group` class on the parent
+- `nth-*` / `nth-last-*` - `nth-3:bg-blue-500`, `nth-[2n+1_of_li]:bg-gray-100`
+- `pointer-coarse:` / `pointer-fine:` - adapt to touch vs mouse input: `pointer-coarse:p-4`
+- `user-valid:` / `user-invalid:` - form validation styles only after user interaction
+- `inert`, `noscript:`, `inverted-colors:` - accessibility and environment states
+- Safe alignment: `justify-center-safe` falls back to `start` when content overflows
+
+### Logical Properties (v4.2)
+
+Use logical utilities for direction-aware layouts (RTL, vertical writing modes):
+
+```html
+<!-- Block-direction margin, padding, and borders -->
+<div class="mbs-6 mbe-2 pbs-4 pbe-8 border-bs border-be-2"><!-- ... --></div>
+
+<!-- Logical sizing -->
+<div class="block-64 inline-full max-inline-lg"><!-- ... --></div>
+
+<!-- Logical inset (replaces deprecated start-*/end-*) -->
+<div class="absolute inset-s-0 inset-e-4 inset-bs-2 inset-be-8"><!-- ... --></div>
+```
+
+### New Color Palettes (v4.2)
+
+Four neutral-ish palettes were added to the default theme: `mauve`, `olive`, `mist`, and `taupe`:
+
+```html
+<div class="bg-mauve-950 text-mauve-100">Mauve</div>
+<div class="border border-mist-200 shadow-taupe-950/10">Mist and taupe</div>
+```
+
+### Font Features (v4.2)
+
+Use `font-features-*` to control OpenType features via `font-feature-settings`:
+
+```html
+<div class='font-features-["tnum"]'>1,234.56 (tabular numbers)</div>
+```
+
+### Scrollbar Styling (v4.3)
+
+Use first-party scrollbar utilities instead of plugins or custom CSS:
+
+```html
+<!-- Scrollbar width and colors (with opacity modifier support) -->
+<div class="scrollbar-thin scrollbar-thumb-sky-700 scrollbar-track-sky-100 overflow-auto">
+  <!-- ... -->
+</div>
+
+<!-- Reserve gutter space to prevent layout shift -->
+<div class="scrollbar-gutter-stable overflow-auto"><!-- ... --></div>
+```
+
+### Zoom and Tab Size (v4.3)
+
+```html
+<div class="zoom-75">Zoomed out</div>
+<pre class="tab-2">Two-space tabs</pre>
+```
+
+### Size Container Queries (v4.3)
+
+Use `@container-size` when you need block-direction container units (`cqb`, `cqh`):
+
+```html
+<div class="@container-size">
+  <div class="h-[50cqb]"><!-- Half the container's block size --></div>
 </div>
 ```
 
@@ -358,8 +505,12 @@ ul {
 2. **Redundant breakpoint classes** - Only specify changes
 3. **Space utilities in flex/grid** - Always use gap
 4. **Leading utilities** - Use line-height modifiers like `text-sm/6`
-5. **Arbitrary values** - Use the design scale
-6. **@apply directive** - Use components or CSS variables
+5. **Arbitrary values** - Always use Tailwind's predefined scale whenever possible (e.g., use `ml-4` over `ml-[16px]`)
+6. **@apply directive** - Use `@utility`, components, or CSS variables
 7. **min-h-screen on mobile** - Use min-h-dvh
 8. **Separate width/height** - Use size utilities when equal
-9. **Arbitrary values** - Always use Tailwind's predefined scale whenever possible (e.g., use `ml-4` over `ml-[16px]`)
+9. **Dynamically constructed class names** - Always write complete class names so the scanner can detect them
+10. **`start-*`/`end-*` utilities** - Deprecated in v4.2, use `inset-s-*`/`inset-e-*`
+11. **`theme()` function in CSS** - Deprecated, use CSS variables like `var(--color-red-500)`
+12. **Important prefix position** - `bg-red-500!` (suffix), not `!bg-red-500`
+13. **Custom scrollbar CSS or plugins** - Use first-party `scrollbar-*` utilities (v4.3)


### PR DESCRIPTION
## Summary

Updates the Tailwind CSS code standards to reflect the current state of Tailwind as of July 2026 (latest stable **v4.3.2**, no v4.4/v5 yet). Findings verified against the official blog, changelog, and docs, cross-checked with an independent research pass.

### Version & accuracy fixes
- Bump baseline from v4.1+ to **v4.3+**
- Add `start-*`/`end-*` deprecation (v4.2) → `inset-s-*`/`inset-e-*`
- Clarify bare `ring`/`shadow`/`blur`/`rounded` are valid v4 classes with different values than v3, `outline-none` vs `outline-hidden` semantics, font-size table shows theme defaults, `dark:` variant ordering is a convention (v4 stacks left-to-right)

### Removed
- v3→v4 migration workflow section (v4 has been out since Jan 2025). The deprecated/renamed utility tables stay, reframed as a legacy reference — their job is preventing LLMs from emitting v3 class names, not aiding migration

### Added
- **Class detection rules**: never construct class names dynamically; `@source`, `@source not`, `@source inline()` safelisting
- **v4 syntax rules**: suffix important modifier (`bg-red-500!`), CSS variable shorthand `bg-(--var)`, `prefix(tw)`, `theme()` deprecation
- **Custom utilities/variants**: `@utility` (with `--value()`/`--default()`), `@custom-variant`, stacked/compound `@variant` (v4.3), `@reference`, `--alpha()`
- **Feature coverage**: v4.0/v4.1 variants (`not-*`, `starting:`, `in-*`, `nth-*`, `pointer-coarse:`, `user-valid:`, safe alignment), text wrapping (v4.1), logical properties (v4.2), mauve/olive/mist/taupe palettes (v4.2), `font-features-*` (v4.2), scrollbar styling (v4.3), `zoom-*`/`tab-*` (v4.3), `@container-size` (v4.3)
- Deduped and extended the common pitfalls list

🤖 Generated with [Claude Code](https://claude.com/claude-code)